### PR TITLE
Fixed a compiler warning / error in the debug function generator when…

### DIFF
--- a/flexc++/generator/conflicts.cc
+++ b/flexc++/generator/conflicts.cc
@@ -12,16 +12,16 @@ bool Generator::conflicts() const
     if (Stat(classHeaderPath))
     {
         ret = errExisting(classHeaderPath, "class-name",
-                                "^\\s*class\\s*" + d_options.className() + "\\b")
+                                "^\\s*class\\s+" + d_options.className() + "\\b")
               or ret;
 
         if (not d_options.nameSpace().empty())
             ret = errExisting(classHeaderPath, "namespace",
-                            "^\\s*namespace\\s*" + d_options.nameSpace() + "\\b")
+                            "^\\s*namespace\\s+" + d_options.nameSpace() + "\\b")
                   or ret;
 
         ret = errExisting(classHeaderPath, Options::baseclassHeaderSpec(), 
-                    "^\\s*#include\\s*\"" + d_options.baseclassHeaderName() + '"')
+                    "^\\s*#include\\s+\"" + d_options.baseclassHeaderName() + '"')
               or ret;
     }
 
@@ -29,7 +29,7 @@ bool Generator::conflicts() const
 
     if (Stat(implementationHeader))
         ret = errExisting(implementationHeader, d_options.classHeaderSpec(), 
-                        "^\\s*#include\\s*\"" + d_options.classHeaderName() + '"')
+                        "^\\s*#include\\s+\"" + d_options.classHeaderName() + '"')
               or ret;
 
     return ret;

--- a/flexc++/generator/conflicts.cc
+++ b/flexc++/generator/conflicts.cc
@@ -12,16 +12,16 @@ bool Generator::conflicts() const
     if (Stat(classHeaderPath))
     {
         ret = errExisting(classHeaderPath, "class-name",
-                                "^class " + d_options.className() + "\\b")
+                                "^\\s*class\\s*" + d_options.className() + "\\b")
               or ret;
 
         if (not d_options.nameSpace().empty())
             ret = errExisting(classHeaderPath, "namespace",
-                            "^namespace " + d_options.nameSpace() + "\\b")
+                            "^\\s*namespace\\s*" + d_options.nameSpace() + "\\b")
                   or ret;
 
         ret = errExisting(classHeaderPath, Options::baseclassHeaderSpec(), 
-                    "^#include \"" + d_options.baseclassHeaderName() + '"')
+                    "^\\s*#include\\s*\"" + d_options.baseclassHeaderName() + '"')
               or ret;
     }
 
@@ -29,7 +29,7 @@ bool Generator::conflicts() const
 
     if (Stat(implementationHeader))
         ret = errExisting(implementationHeader, d_options.classHeaderSpec(), 
-                        "^#include \"" + d_options.classHeaderName() + '"')
+                        "^\\s*#include\\s*\"" + d_options.classHeaderName() + '"')
               or ret;
 
     return ret;

--- a/flexc++/generator/conflicts.cc
+++ b/flexc++/generator/conflicts.cc
@@ -12,16 +12,16 @@ bool Generator::conflicts() const
     if (Stat(classHeaderPath))
     {
         ret = errExisting(classHeaderPath, "class-name",
-                                "^class " + d_options.className() + "\\b")
+                                "^\s*class\s*" + d_options.className() + "\\b")
               or ret;
 
         if (not d_options.nameSpace().empty())
             ret = errExisting(classHeaderPath, "namespace",
-                            "^namespace " + d_options.nameSpace() + "\\b")
+                            "^\s*namespace\s*" + d_options.nameSpace() + "\\b")
                   or ret;
 
         ret = errExisting(classHeaderPath, Options::baseclassHeaderSpec(), 
-                    "^#include \"" + d_options.baseclassHeaderName() + '"')
+                    "^\s*#include\s*\"" + d_options.baseclassHeaderName() + '"')
               or ret;
     }
 
@@ -29,7 +29,7 @@ bool Generator::conflicts() const
 
     if (Stat(implementationHeader))
         ret = errExisting(implementationHeader, d_options.classHeaderSpec(), 
-                        "^#include \"" + d_options.classHeaderName() + '"')
+                        "^\s*#include\s*\"" + d_options.classHeaderName() + '"')
               or ret;
 
     return ret;

--- a/flexc++/generator/debugfunctions.cc
+++ b/flexc++/generator/debugfunctions.cc
@@ -8,7 +8,7 @@ void Generator::debugFunctions(std::ostream &out) const
     {
         out << 
             "void " << d_baseclassScope << "setDebug(bool onOff)\n"
-            "{}\n"
+            "{ (void)(onOff); }\n"
             "\n"
             "bool " << d_baseclassScope << "debug() const\n"
             "{\n"

--- a/flexc++/generator/inputimplementation.cc
+++ b/flexc++/generator/inputimplementation.cc
@@ -24,7 +24,10 @@ void Generator::inputImplementation(ostream &out) const
 :
     d_in(iStream),
     d_lineNr(lineNr)
-{}
+{
+    if(not *iStream)
+        throw std::runtime_error("Cannot read from stream");
+}
 
 size_t )" << d_baseclassScope << R"(Input::get()
 {


### PR DESCRIPTION
Fixed a compiler warning / error in the debug function generator when unused variables are treated as such. This occurs when GCC builds with -Werror=unused-parameter.